### PR TITLE
Elasticache

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -1,21 +1,18 @@
 #!/usr/bin/env node
-import 'source-map-support/register';
-import * as cdk from 'aws-cdk-lib';
-import { CdkStack } from '../lib/cdk-stack';
+import "source-map-support/register";
+import * as cdk from "aws-cdk-lib";
+import { WebsocketServerEcsStack } from "../lib/websocket-server-ecs-stack";
 
 const app = new cdk.App();
-new CdkStack(app, 'CdkStack', {
+new WebsocketServerEcsStack(app, "CdkStack", {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */
-
   /* Uncomment the next line to specialize this stack for the AWS Account
    * and Region that are implied by the current CLI configuration. */
   // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
-
   /* Uncomment the next line if you know exactly what Account and Region you
    * want to deploy the stack to. */
   // env: { account: '123456789012', region: 'us-east-1' },
-
   /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
 });

--- a/lib/Elasticache.ts
+++ b/lib/Elasticache.ts
@@ -1,0 +1,46 @@
+import { Construct } from "constructs";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as elasticache from "aws-cdk-lib/aws-elasticache";
+
+export class Elasticache extends Construct {
+  redisEndpointAddress: string;
+  redisEndpointPort: string;
+
+  constructor(scope: Construct, id: string, vpc: ec2.IVpc) {
+    super(scope, id);
+
+    const redisSecurityGroup = new ec2.SecurityGroup(
+      this,
+      "RedisSecurityGroup",
+      {
+        vpc,
+        securityGroupName: "redis-sec-group",
+        allowAllOutbound: true,
+      }
+    );
+
+    redisSecurityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(6379));
+
+    const subnetRedisGroup = new elasticache.CfnSubnetGroup(
+      this,
+      "ElasticacheSubnetGroup",
+      {
+        description: "Subnet group for Redis Elasticache",
+        subnetIds: vpc.publicSubnets.map((subnet) => subnet.subnetId),
+      }
+    );
+
+    const redis = new elasticache.CfnCacheCluster(this, "Redis", {
+      cacheNodeType: "cache.t3.micro",
+      engine: "redis",
+      numCacheNodes: 1,
+      vpcSecurityGroupIds: [redisSecurityGroup.securityGroupId],
+      cacheSubnetGroupName: subnetRedisGroup.ref,
+    });
+
+    redis.addDependency(subnetRedisGroup);
+
+    this.redisEndpointAddress = redis.attrRedisEndpointAddress;
+    this.redisEndpointPort = redis.attrRedisEndpointPort;
+  }
+}

--- a/lib/websocket-server-ecs-stack.ts
+++ b/lib/websocket-server-ecs-stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
+import { Elasticache } from "./Elasticache";
 import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 
@@ -7,12 +8,11 @@ export class WebsocketServerEcsStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    //creates the virtual private networkv
     const vpc = new ec2.Vpc(this, "MyVpc", { maxAzs: 2 });
-    //create the cluster where we will deploy our container, called MyCluster
-    //uses the vpc that we defined above
     const cluster = new ecs.Cluster(this, "MyCluster", { vpc });
-    //creates a taskDefinition
+
+    const elasticache = new Elasticache(scope, id, vpc);
+
     const taskDefinition = new ecs.FargateTaskDefinition(
       this,
       "websocket-task-file",
@@ -22,28 +22,42 @@ export class WebsocketServerEcsStack extends cdk.Stack {
       }
     );
 
-    //We are adding the container to the taskDefinition, and information
+    const serviceSecurityGroup = new ec2.SecurityGroup(
+      this,
+      "serviceSecurityGroups",
+      {
+        vpc,
+        securityGroupName: "fargate-service-sec-group",
+      }
+    );
+
+    serviceSecurityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(8000),
+      "Allow access to port 8000 from any IP"
+    );
+
     taskDefinition.addContainer("MyContainer", {
       image: ecs.ContainerImage.fromRegistry(
         "public.ecr.aws/q8e0a8z0/websocket-server:latest"
-      ), //works because it is public.
+      ),
       memoryLimitMiB: 2048,
       cpu: 1024,
       portMappings: [{ containerPort: 8000 }],
+      environment: {
+        REDIS_ENDPOINT_ADDRESS: elasticache.redisEndpointAddress,
+        REDIS_ENDPOINT_PORT: elasticache.redisEndpointPort
+      },
     });
 
     const service = new ecs.FargateService(this, "WebsocketFargateService", {
       cluster,
       taskDefinition,
       desiredCount: 1,
-      assignPublicIp: true, //Give this badboy a public ip address
+      assignPublicIp: true,
+      securityGroups: [serviceSecurityGroup],
     });
-    //This allows us to access the container directly from the internet
-    const securityGroup = service.connections.securityGroups[0];
-    securityGroup.addIngressRule(
-      ec2.Peer.anyIpv4(),
-      ec2.Port.tcp(8000),
-      "Allow access to port 8000 from any IP"
-    );
+
+    service.node.addDependency(elasticache);
   }
 }

--- a/lib/websocket-server-ecs-stack.ts
+++ b/lib/websocket-server-ecs-stack.ts
@@ -7,7 +7,7 @@ export class WebsocketServerEcsStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    //creates the virtual private network
+    //creates the virtual private networkv
     const vpc = new ec2.Vpc(this, "MyVpc", { maxAzs: 2 });
     //create the cluster where we will deploy our container, called MyCluster
     //uses the vpc that we defined above

--- a/lib/websocket-server-ecs-stack.ts
+++ b/lib/websocket-server-ecs-stack.ts
@@ -11,14 +11,14 @@ export class WebsocketServerEcsStack extends cdk.Stack {
     const vpc = new ec2.Vpc(this, "MyVpc", { maxAzs: 2 });
     const cluster = new ecs.Cluster(this, "MyCluster", { vpc });
 
-    const elasticache = new Elasticache(scope, id, vpc);
+    const elasticache = new Elasticache(this, id, vpc);
 
     const taskDefinition = new ecs.FargateTaskDefinition(
       this,
       "websocket-task-file",
       {
-        cpu: 1024,
-        memoryLimitMiB: 2048,
+        cpu: 512,
+        memoryLimitMiB: 1024,
       }
     );
 
@@ -39,21 +39,21 @@ export class WebsocketServerEcsStack extends cdk.Stack {
 
     taskDefinition.addContainer("MyContainer", {
       image: ecs.ContainerImage.fromRegistry(
-        "public.ecr.aws/q8e0a8z0/websocket-server:latest"
+        "public.ecr.aws/q8e0a8z0/redis-test:latest"
       ),
-      memoryLimitMiB: 2048,
-      cpu: 1024,
+      memoryLimitMiB: 1024,
+      cpu: 512,
       portMappings: [{ containerPort: 8000 }],
       environment: {
         REDIS_ENDPOINT_ADDRESS: elasticache.redisEndpointAddress,
-        REDIS_ENDPOINT_PORT: elasticache.redisEndpointPort
+        REDIS_ENDPOINT_PORT: elasticache.redisEndpointPort,
       },
     });
 
     const service = new ecs.FargateService(this, "WebsocketFargateService", {
       cluster,
       taskDefinition,
-      desiredCount: 1,
+      desiredCount: 2,
       assignPublicIp: true,
       securityGroups: [serviceSecurityGroup],
     });


### PR DESCRIPTION
Created the elasticache module. This module handles the creation of the elasticache(redis) on AWS, using the CDK. Once the elasticache has been created on aws, it will return the connection string information once it has been created, the connection string information will be passed as environment variables to the containers. 

This is specified in the task definition files.

