### PR TITLE
Build: added autoscale task min/max and alarms to scale

### DIFF
--- a/lib/LoadBalancedApplication.ts
+++ b/lib/LoadBalancedApplication.ts
@@ -47,6 +47,19 @@ export class LoadBalancedApplication extends Construct {
 
     const ecs = new ECS(this, id, vpc, albSecurityGroup, elasticache);
 
+    const scalableTarget = ecs.service.autoScaleTaskCount({
+      minCapacity: 2,
+      maxCapacity: 5,
+    });
+
+    scalableTarget.scaleOnCpuUtilization("CpuScaling", {
+      targetUtilizationPercent: 50,
+    });
+
+    scalableTarget.scaleOnMemoryUtilization("MemoryScaling", {
+      targetUtilizationPercent: 50,
+    });
+
     listener.addTargets("WebSocketServer-ECSTargets", {
       port: 80,
       targets: [ecs.service],


### PR DESCRIPTION
I added an auto scaling min/max ability to our ECS service (set it to 2 and 5, respectively).

I also added an alarm that gets created. Whenever a container running in our ECS passes a certain threshold of CPU or memory utilization. I set both threshold's to 50% per AWS recommendation.