### PR TITLE
Fix: updated ARN Certificate check in HTTPS Listener test

### DIFF
--- a/test/cdk.test.ts
+++ b/test/cdk.test.ts
@@ -39,20 +39,13 @@ describe("Testing That Resources are Created...", () => {
     });
   });
 
-  test("HTTPS Listener Created", () => {
-    template.hasResourceProperties("AWS::ElasticLoadBalancingV2::Listener", {
-      Port: 443,
-      Protocol: "HTTPS",
-    });
-  });
-
   test("HTTPS Listener Created with ARN Certificate", () => {
     template.hasResourceProperties("AWS::ElasticLoadBalancingV2::Listener", {
       Port: 443,
       Protocol: "HTTPS",
       Certificates: [
         {
-          CertificateArn: process.env.CERTIFICATE_ARN,
+          CertificateArn: process.env.CERTIFICATE_ARN || "",
         },
       ],
     });


### PR DESCRIPTION
Forgot to add a conditional to check if the ARN is not in the .env file

Also, removed an unnecessary test on the HTTPS listener.