### PR TITLE
Refactor: Updated naming and removed public HTTP

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
-import { WebSocketServerStack } from "../lib/websocket-server-ecs-stack";
+import { CerebellumStack } from "../lib/CreateCerebellumStack";
 import * as dotenv from "dotenv";
 dotenv.config();
 
 const app = new cdk.App();
-new WebSocketServerStack(app, "WebSocketServerStack", {});
+new CerebellumStack(app, "CerebellumStack", {});

--- a/lambda/httpGetMessage.mjs
+++ b/lambda/httpGetMessage.mjs
@@ -1,5 +1,5 @@
 import { getAllMessagesForChannel } from "./utils/getAllMessagesForChannel.js";
-import { getChannel } from "./utils/getChannelId.js";
+import { checkChannelExists } from "./utils/checkChannelExists.js";
 import dynamoose from "dynamoose";
 
 const ddb = new dynamoose.aws.ddb.DynamoDB();
@@ -17,10 +17,9 @@ export const handler = async (event) => {
   try {
     const { channelName } = validateInput(event.queryStringParameters);
 
-    console.log(channelName);
-    const channelId = await getChannel(channelName);
+    await checkChannelExists(channelName);
 
-    const pastMessages = await getAllMessagesForChannel(channelId);
+    const pastMessages = await getAllMessagesForChannel(channelName);
 
     return {
       statusCode: 200,

--- a/lambda/httpPostMessage.mjs
+++ b/lambda/httpPostMessage.mjs
@@ -1,5 +1,5 @@
 import { sendMessageToQueue } from "./utils/sendMessageToQueue.js";
-import { getChannel } from "./utils/getChannelId.js";
+import { checkChannelExists } from "./utils/checkChannelExists.js";
 import { initializeRedis } from "./utils/initializeRedis.js";
 
 const validateInput = (body) => {
@@ -16,15 +16,14 @@ export const handler = async (event) => {
   try {
     const { channelName, content } = validateInput(event.body);
 
-    const channelId = await getChannel(channelName);
+    await checkChannelExists(channelName);
 
     io.to(channelName).emit(`message:receive:${channelName}`, {
       channelName,
-      message: content,
-      sendDescription: "from lambda",
+      content,
     });
 
-    await sendMessageToQueue(channelId, content);
+    await sendMessageToQueue(channelName, content);
 
     return { statusCode: 200, body: "Message processing completed" };
   } catch (error) {

--- a/lambda/messageArchive.mjs
+++ b/lambda/messageArchive.mjs
@@ -37,8 +37,8 @@ export const handler = async (event) => {
       const deleteParams = {
         TableName: process.env.MESSAGES_TABLE_NAME,
         Key: {
-          channelId: item.channelId,
-          createdAt_messageId: item.createdAt_messageId,
+          channelName: item.channelName,
+          messageId: item.messageId,
         },
       };
       await dynamodb.delete(deleteParams).promise();

--- a/lambda/models/channels.js
+++ b/lambda/models/channels.js
@@ -3,15 +3,15 @@ import dynamoose from "dynamoose";
 const ddb = new dynamoose.aws.ddb.DynamoDB();
 dynamoose.aws.ddb.set(ddb);
 
-const channelSchema = new dynamoose.Schema({
+export const channelSchema = new Schema({
   channelName: {
     type: String,
     hashKey: true,
-  },
-  channelId: {
-    type: String,
     required: true,
   },
 });
 
-export const Channel = dynamoose.model("channels", channelSchema);
+export const Channel = dynamoose.model(
+  process.env.DYNAMODB_CHANNELS_TABLE_NAME,
+  channelSchema
+);

--- a/lambda/models/messages.js
+++ b/lambda/models/messages.js
@@ -3,17 +3,17 @@ import { v4 as uuidv4 } from "uuid";
 
 // Define the schema
 const messageSchema = new dynamoose.Schema({
-  channelId: {
+  channelName: {
     type: String,
     hashKey: true,
+    required: true,
   },
-  createdAt_messageId: {
+
+  messageId: {
     type: String,
     rangeKey: true,
     default: () => {
-      const now = new Date();
-      const uniqueId = uuidv4();
-      return `${now.toISOString().padStart(20, "0")}_${uniqueId}`;
+      return uuidv4();
     },
   },
   content: {
@@ -22,6 +22,10 @@ const messageSchema = new dynamoose.Schema({
   },
   createdAt: {
     type: String,
+    index: {
+      name: "createdAtIndex",
+      type: "local",
+    },
     required: true,
     default: () => {
       const now = new Date();
@@ -30,4 +34,7 @@ const messageSchema = new dynamoose.Schema({
   },
 });
 
-export const Message = dynamoose.model("messages", messageSchema);
+export const Message = dynamoose.model(
+  process.env.DYNAMODB_MESSAGES_TABLE_NAME,
+  messageSchema
+);

--- a/lambda/saveMessageToDatabase.mjs
+++ b/lambda/saveMessageToDatabase.mjs
@@ -8,15 +8,15 @@ dynamoose.aws.ddb.set(ddb);
 export const handler = async (event) => {
   console.log("Received event:", event);
 
-  const { channelId, createdAt, createdAt_messageId, content } = JSON.parse(
+  const { channelName, messageId, content, createdAt } = JSON.parse(
     event.Records[0].body
   );
 
   const newMessage = new Message({
-    channelId,
-    createdAt,
-    createdAt_messageId,
+    channelName,
+    messageId,
     content,
+    createdAt,
   });
 
   try {

--- a/lambda/utils/checkChannelExists.js
+++ b/lambda/utils/checkChannelExists.js
@@ -1,9 +1,8 @@
 import { Channel } from "../models/channels.js";
 
-export const getChannel = async (channelName) => {
+export const validateChannelName = async (channelName) => {
   const channel = await Channel.query("channelName").eq(channelName).exec();
   if (channel.length === 0) {
     throw new Error(`No channel found matching name: ${channelName}`);
   }
-  return channel[0].channelId;
 };

--- a/lambda/utils/getAllMessagesForChannel.js
+++ b/lambda/utils/getAllMessagesForChannel.js
@@ -1,11 +1,11 @@
 import { Message } from "../models/messages.js";
 
-export const getAllMessagesForChannel = async (channelId) => {
+export const getAllMessagesForChannel = async (channelName) => {
   try {
-    const messages = await Message.query("channelId").eq(channelId).exec();
+    const messages = await Message.query("channelName").eq(channelName).exec();
 
     const contents = messages.map((message) => {
-      return { time: message.createdAt, content: message.content };
+      return { content: message.content, createdAt: message.createdAt };
     });
     return contents;
   } catch (error) {

--- a/lambda/utils/sendMessageToQueue.js
+++ b/lambda/utils/sendMessageToQueue.js
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 
 const sqs = new SQSClient();
 
-export const sendMessageToQueue = async (channelId, message) => {
+export const sendMessageToQueue = async (channelName, content) => {
   // Use the queue URL from an environment variable or configuration
 
   const now = new Date();
@@ -12,10 +12,10 @@ export const sendMessageToQueue = async (channelId, message) => {
   const params = {
     QueueUrl: process.env.QUEUE_URL,
     MessageBody: JSON.stringify({
-      channelId,
-      createdAt_messageId: `${now.toISOString().padStart(20, "0")}_${uuidv4()}`,
-      content: `${message} => From Lambda API`,
-      createdAt: now.toISOString(),
+      channelName,
+      messageId: uuidv4(),
+      content,
+      createdAt: `${now.toISOString()}`,
     }),
   };
 

--- a/lib/CreateCerebellumStack.ts
+++ b/lib/CreateCerebellumStack.ts
@@ -4,17 +4,17 @@ import { Elasticache } from "./Elasticache";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { LoadBalancer } from "./LoadBalancer";
 
-export class WebSocketServerStack extends cdk.Stack {
+export class CerebellumStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    const vpc = new ec2.Vpc(this, "WebSocketServer-Vpc", {
+    const vpc = new ec2.Vpc(this, "CerebellumVpc", {
       maxAzs: 2,
       natGateways: 1,
     });
 
-    const elasticache = new Elasticache(this, "Elasticache", vpc);
+    const elasticache = new Elasticache(this, "CerebellumElasticache", vpc);
 
-    new LoadBalancer(this, "ALB", vpc, elasticache);
+    new LoadBalancer(this, "CerebellumALB", vpc, elasticache);
   }
 }

--- a/lib/Elasticache.ts
+++ b/lib/Elasticache.ts
@@ -11,7 +11,7 @@ export class Elasticache extends Construct {
 
     const redisSecurityGroup = new ec2.SecurityGroup(
       this,
-      "RedisSecurityGroup",
+      "CerebellumRedisSecurityGroup",
       {
         vpc,
         securityGroupName: "redis-sec-group",
@@ -23,27 +23,12 @@ export class Elasticache extends Construct {
 
     const subnetRedisGroup = new elasticache.CfnSubnetGroup(
       this,
-      "ElasticacheSubnetGroup",
+      "CerebellumElasticacheSubnetGroup",
       {
         description: "Subnet group for Redis Elasticache",
         subnetIds: vpc.publicSubnets.map((subnet) => subnet.subnetId),
       }
     );
-
-    // const redis = new elasticache.CfnReplicationGroup(
-    //   this,
-    //   "RedisReplicationGroup",
-    //   {
-    //     replicationGroupDescription: "Redis replication group",
-    //     engine: "redis",
-    //     cacheNodeType: "cache.t3.micro",
-    //     numNodeGroups: 1,
-    //     replicasPerNodeGroup: 1, // 1 primary + 1 replica
-    //     automaticFailoverEnabled: true,
-    //     securityGroupIds: [redisSecurityGroup.securityGroupId],
-    //     cacheSubnetGroupName: subnetRedisGroup.ref,
-    //   }
-    // );
 
     // LEGACY
     const redis = new elasticache.CfnCacheCluster(this, "Redis", {
@@ -55,11 +40,6 @@ export class Elasticache extends Construct {
     });
 
     redis.addDependency(subnetRedisGroup);
-
-    // // Note: For replication groups, endpoint is not available as an attribute directly
-    // // Instead, you can use the configuration endpoint of the replication group
-    // this.redisEndpointAddress = redis.attrConfigurationEndPointAddress;
-    // this.redisEndpointPort = redis.attrConfigurationEndPointPort;
 
     // LEGACY
     this.redisEndpointAddress = redis.attrRedisEndpointAddress;

--- a/lib/MessageArchive.ts
+++ b/lib/MessageArchive.ts
@@ -11,11 +11,14 @@ export class MessageArchive extends Construct {
     super(scope, id);
 
     // Define the S3 bucket where "old data" can be moved to
-    const messageArchiveS3 = new s3.Bucket(this, "MessageArchiveBucket");
+    const messageArchiveS3 = new s3.Bucket(
+      this,
+      "CerebellumMessageArchiveBucket"
+    );
 
     const messageArchiveLambda = new lambda.Function(
       this,
-      "MessageArchiveLambda",
+      "CerebellumMessageArchiveLambda",
       {
         runtime: lambda.Runtime.NODEJS_20_X,
         handler: "messageArchive.handler",
@@ -34,7 +37,7 @@ export class MessageArchive extends Construct {
 
     const messageArchiveCronJob = new events.Rule(
       this,
-      "MessageArchiveCronJob",
+      "CerebellumMessageArchiveCronJob",
       {
         schedule: events.Schedule.cron({
           minute: "0",

--- a/test/cdk.test.ts
+++ b/test/cdk.test.ts
@@ -1,6 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import * as Cdk from "../lib/websocket-server-ecs-stack";
+import * as Cdk from "../lib/CreateCerebellumStack";
 import { before } from "node:test";
 
 describe("Testing That Resources are Created...", () => {
@@ -9,7 +9,7 @@ describe("Testing That Resources are Created...", () => {
   before(() => {
     const app = new cdk.App();
     // WHEN
-    const stack = new Cdk.WebSocketServerStack(app, "MyTestStack");
+    const stack = new Cdk.CerebellumStack(app, "MyTestStack");
     // THEN
     template = Template.fromStack(stack);
   });


### PR DESCRIPTION
# Changes

### Identification

- Changed the identifiers to include Cerebellum so that the developer will know which items on their AWS are involved in the Cerebellum-produced infrastructure

### HTTP

- Wanted to remove attacker’s ability to DDoS the server by removing public HTTP accessibility. Now, only those with HTTPS connection (via mandated approved SSL/TLS certificate management) will be able to access the server. To do so:
    - Removed HTTP ingress rules in the ALB security group
    - Removed HTTP listener and target for the ALB

### DynamoDB

- Updated column names and added index to match the server and SDK code

### Lambdas

- Added DynamoDB table names as `.env` variables to the HTTPPost/HttpGet lambdas
- Revised `channelName`  to be used as identifier instead of `channelId`